### PR TITLE
Update 02_ops.scala

### DIFF
--- a/src/main/scala/net/degoes/02_ops.scala
+++ b/src/main/scala/net/degoes/02_ops.scala
@@ -384,7 +384,7 @@ object education {
   }
 
   final case class QuizResult(correctPoints: Int, bonusPoints: Int, wrongPoints: Int, wrong: Vector[String]) {
-    def totalPoints: Int = correctPoints + wrongPoints
+    def totalPoints: Int = correctPoints - wrongPoints
 
     def toBonus: QuizResult = QuizResult(0, bonusPoints + correctPoints, 0, Vector.empty)
 


### PR DESCRIPTION
QuizResult totalPoints seems to have been oversight typo. Severe grading should deduct wrong points, permissive grading should toss out wrong points but we should never add them to correct points.