### PR TITLE
consume input for parser of OneChar

### DIFF
--- a/src/main/scala/net/degoes/06_gadts.scala
+++ b/src/main/scala/net/degoes/06_gadts.scala
@@ -156,7 +156,7 @@ object parser {
     parser match {
       case OneChar =>
         input.headOption
-          .map((a: Char) => Right(input -> a))
+          .map((a: Char) => Right(input.drop(1) -> a))
           .getOrElse(Left("The input to the parser has no remaining characters"))
     }
 }


### PR DESCRIPTION
I confirm that you agree that input returned on Success (Right) along with A should be consumed as is standard in parsers and what you actually stated around 29:00-31:00 for second session on second day for London audience.