### PR TITLE
fix typo comment in 07_patterns EXERCISE 4

### DIFF
--- a/src/main/scala/net/degoes/07_patterns.scala
+++ b/src/main/scala/net/degoes/07_patterns.scala
@@ -80,7 +80,7 @@ object binary_values {
      * function in such a way that:
      *
      * {{{
-     * compose(a, b) == compose(b, c)
+     * compose(a, b) == compose(b, a)
      * }}}
      *
      * for all `a`, `b`.


### PR DESCRIPTION
exercices 3 and 4 are commutative, #3 got fixed during class but not #4.