### PR TITLE
update to scala 2.13, ZIO 1.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,30 +1,30 @@
 import sbt._
 
-lazy val functionalDesign = (project in file(".")).
-  settings (
-    name := "Functional Design",
-    organization := "net.degoes",
-    version := "0.1-SNAPSHOT",
-    scalaVersion := "2.12.10"
-    // add other settings here
-  )
+lazy val functionalDesign = (project in file(".")).settings(
+  name := "Functional Design",
+  organization := "net.degoes",
+  version := "0.1-SNAPSHOT",
+  scalaVersion := "2.13.3"
+  // add other settings here
+)
 
 /* scala versions and options */
-scalaVersion := "2.12.10"
+scalaVersion := "2.13.3"
 
-addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.6")
+addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full)
 
 // These options will be used for *all* versions.
 scalacOptions ++= Seq(
-  "-deprecation"
-  , "-unchecked"
-  , "-encoding", "UTF-8"
-  , "-Xlint"
-  , "-Xverify"
-  , "-feature"
-  ,"-Ypartial-unification"
+  "-deprecation",
+  "-unchecked",
+  "-encoding",
+  "UTF-8",
+  "-Xlint",
+  "-Xverify",
+  "-feature"
   //,"-Xfatal-warnings" // Recommend enable before you commit code
-  , "-language:_"
+  ,
+  "-language:_"
   //,"-optimise"
 )
 
@@ -39,24 +39,24 @@ javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation", "-source", "1.7",
 //   "-J-XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=100M"
 // )
 
-val CatsVersion = "2.1.0"
+val CatsVersion       = "2.1.0"
 val CatsEffectVersion = "2.1.1"
-val MonixVersion = "3.1.0"
-val ZIOVersion = "1.0.0-RC18-2"
-val ShapelessVersion = "2.3.3"
-val FS2Version = "2.2.2"
-val AmmoniteVersion = "2.0.0"
+val MonixVersion      = "3.1.0"
+val ZIOVersion        = "1.0.0"
+val ShapelessVersion  = "2.3.3"
+val FS2Version        = "2.2.2"
+val AmmoniteVersion   = "2.2.0"
 
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.3.1",
   // -- testing --
-  "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+  "org.scalacheck" %% "scalacheck" % "1.14.1" % "test",
+  "org.scalatest"  %% "scalatest"  % "3.2.0"  % "test",
   // -- Logging --
-  "ch.qos.logback" % "logback-classic" % "1.1.3",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",
+  "ch.qos.logback"             % "logback-classic" % "1.1.3",
+  "com.typesafe.scala-logging" %% "scala-logging"  % "3.9.2",
   // Cats
-  "org.typelevel" %% "cats-core" % CatsVersion,
+  "org.typelevel" %% "cats-core"   % CatsVersion,
   "org.typelevel" %% "cats-effect" % CatsEffectVersion,
   // fs2
   "co.fs2" %% "fs2-core" % FS2Version,
@@ -65,10 +65,10 @@ libraryDependencies ++= Seq(
   // shapeless
   "com.chuusai" %% "shapeless" % ShapelessVersion,
   // scalaz
-  "dev.zio" %% "zio" % ZIOVersion,
+  "dev.zio" %% "zio"         % ZIOVersion,
   "dev.zio" %% "zio-streams" % ZIOVersion,
   // type classes
-  "com.github.mpilquist" %% "simulacrum" % "0.12.0",
+  "org.typelevel" %% "simulacrum" % "1.0.0",
   // li haoyi ammonite repl embed
   "com.lihaoyi" % "ammonite" % AmmoniteVersion % "test" cross CrossVersion.full
 )
@@ -85,4 +85,3 @@ sourceGenerators in Test += Def.task {
   IO.write(file, """object amm extends App { ammonite.Main().run() }""")
   Seq(file)
 }.taskValue
-

--- a/src/main/scala/net/degoes/00_intro.scala
+++ b/src/main/scala/net/degoes/00_intro.scala
@@ -54,9 +54,9 @@ object tour {
       val qworkers = List.fill(count)(qworker)
 
       (for {
-        fiber <- ZIO.forkAll(qworkers)
+        fiber <- ZIO.forkAll(qworkers.map(_.flatMap(_ => ZIO.unit)))
         list  <- fiber.join
-      } yield list.head).flip
+      } yield list.head).flatMap(_ => ZIO.never).flip
     }
   }
 

--- a/src/main/scala/net/degoes/02_ops.scala
+++ b/src/main/scala/net/degoes/02_ops.scala
@@ -396,7 +396,11 @@ object ui_events {
      * Add a method `+` that composes two listeners into a single listener,
      * by sending each game event to both listeners.
      */
-    def +(that: Listener): Listener = ???
+    def +(that: Listener): Listener =
+      Listener { event =>
+        self.onEvent(event)
+        that.onEvent(event)
+      }
 
     /**
      * EXERCISE 2
@@ -470,7 +474,13 @@ object education {
      * Add a `+` operator that combines this quiz result with the specified
      * quiz result.
      */
-    def +(that: QuizResult): QuizResult = ???
+    def +(that: QuizResult): QuizResult =
+      QuizResult(
+        self.correctPoints + that.correctPoints,
+        self.bonusPoints + that.bonusPoints,
+        self.wrongPoints + that.wrongPoints,
+        self.wrong ++ that.wrong
+      )
   }
   object QuizResult {
 
@@ -543,7 +553,7 @@ object education {
      * Add an `empty` Quiz that does not ask any questions and only returns
      * an empty QuizResult.
      */
-    def empty: Quiz = ???
+    def empty: Quiz = Quiz(() => QuizResult.empty)
   }
 
   final case class Checker[-A](points: Int, isCorrect: A => Either[String, Unit])

--- a/src/main/scala/net/degoes/02_ops.scala
+++ b/src/main/scala/net/degoes/02_ops.scala
@@ -396,11 +396,7 @@ object ui_events {
      * Add a method `+` that composes two listeners into a single listener,
      * by sending each game event to both listeners.
      */
-    def +(that: Listener): Listener =
-      Listener { event =>
-        self.onEvent(event)
-        that.onEvent(event)
-      }
+    def +(that: Listener): Listener = ???
 
     /**
      * EXERCISE 2
@@ -474,13 +470,7 @@ object education {
      * Add a `+` operator that combines this quiz result with the specified
      * quiz result.
      */
-    def +(that: QuizResult): QuizResult =
-      QuizResult(
-        self.correctPoints + that.correctPoints,
-        self.bonusPoints + that.bonusPoints,
-        self.wrongPoints + that.wrongPoints,
-        self.wrong ++ that.wrong
-      )
+    def +(that: QuizResult): QuizResult = ???
   }
   object QuizResult {
 
@@ -553,7 +543,7 @@ object education {
      * Add an `empty` Quiz that does not ask any questions and only returns
      * an empty QuizResult.
      */
-    def empty: Quiz = Quiz(() => QuizResult.empty)
+    def empty: Quiz = ???
   }
 
   final case class Checker[-A](points: Int, isCorrect: A => Either[String, Unit])


### PR DESCRIPTION
I managed to resolve the following compilation error (invalid usage of forkAll) by flat mapping qworker to ZIO.unit and then back to ZIO.never. Disclaimer: I have ZERO experience with ZIO.

```
00_intro.scala:57:29: Cannot construct a collection of type List[A] with elements of type A based on a collection of type List[zio.ZIO[Any,Throwable,A]].
[error]         fiber <- ZIO.forkAll(qworkers)
[error]                             ^
[error] one error found
[error] (Compile / compileIncremental) Compilation failed
```
